### PR TITLE
Refactor `Source` to store the specific matched pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Changed
 
 - Add support for nonstandard morphological information types.
+- Fix issue where all morph information for an affix rule were being reported,
+  rather than just that for the relevant pattern. Fixes
+  [#73](https://github.com/pluots/zspell/issues/73).
 
 ### Removed
 

--- a/test-suite/numbers.test
+++ b/test-suite/numbers.test
@@ -29,6 +29,8 @@ SFX 10 0 000 . is:thousands
 90
 900
 
-%% ==== morph ====
+==== morph ====
 %% FIXME:dict-parser should have po:number
-%% FIXME:afx-morph 900 > po:number
+%% 900 > po:number
+10 > is:tens
+600 > is:hundreds


### PR DESCRIPTION
Save the index of the relevant `AfxRulePattern` with the `Arc<Affix>` in `Source::Affix`. This allows us to retrieve morph rules from that specific pattern, rather than returning all rules in the `Affix`.

Fixes #73