### PR TITLE
handle multiples character in flag parsing

### DIFF
--- a/zspell/src/affix/parse.rs
+++ b/zspell/src/affix/parse.rs
@@ -137,7 +137,7 @@ where
 
         // Max length is 10 for u32::max. We will validate our flag later
         if count <= 10 && valid {
-            Ok(f(s.chars().next().unwrap().to_string()))
+            Ok(f(s.to_owned()))
         } else {
             Err(ParseError::new_nospan(ParseErrorKind::InvalidFlag, s))
         }


### PR DESCRIPTION
flag allow multiple characters, but only the first one was take.
In fr hunspell dictionary, `()`, `{}`, `||`, `--` are used as flags.
This change create a String with all characters, not only the first on.
Without this change, the french dictionary failed to load.

I have tested than `en` dictionary always load, but I haven't particularly tested it more.

Fixes #108